### PR TITLE
Fix, ray data structure

### DIFF
--- a/2_autolens_rms.py
+++ b/2_autolens_rms.py
@@ -157,7 +157,7 @@ def curriculum_design(
 
             # Ray error to center and valid mask
             ray_xy = ray.o[..., :2]
-            ray_valid = ray.valid
+            ray_valid = ray.is_valid
             ray_err = ray_xy - center_ref
 
             # Weight mask (non-differentiable), shape of [num_grid, num_grid]

--- a/6_hybridlens_design.py
+++ b/6_hybridlens_design.py
@@ -16,7 +16,7 @@ from torchvision.utils import save_image
 from tqdm import tqdm
 
 from deeplens.hybridlens import HybridLens
-from deeplens.optics.utils import PSFLoss
+from deeplens.optics.loss import PSFLoss
 from deeplens.utils import set_logger, set_seed
 
 

--- a/deeplens/geolens.py
+++ b/deeplens/geolens.py
@@ -36,7 +36,7 @@ from deeplens.geolens_pkg.eval import GeoLensEval
 from deeplens.geolens_pkg.io import GeoLensIO
 from deeplens.geolens_pkg.optim import GeoLensOptim
 from deeplens.geolens_pkg.tolerance import GeoLensTolerance
-# from deeplens.geolens_pkg.view_3d import GeoLensVis3D
+from deeplens.geolens_pkg.view_3d import GeoLensVis3D
 from deeplens.geolens_pkg.vis import GeoLensVis
 from deeplens.lens import Lens
 from deeplens.optics.geometric_surface import (
@@ -61,7 +61,7 @@ from deeplens.utils import (
 )
 
 
-class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTolerance): #, GeoLensVis3D):
+class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTolerance, GeoLensVis3D):
     def __init__(
         self,
         filename=None,
@@ -866,8 +866,8 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
             img_render = torch.clamp(img_render, 0, 1)
 
         # Compute PSNR and SSIM
-        render_psnr = round(batch_psnr(img, img_render), 3)
-        render_ssim = round(batch_ssim(img, img_render), 3)
+        render_psnr = round(batch_psnr(img, img_render).item(), 3)
+        render_ssim = round(batch_ssim(img, img_render).item(), 3)
         print(f"Rendered image: PSNR={render_psnr:.3f}, SSIM={render_ssim:.3f}")
 
         # Save image
@@ -879,8 +879,8 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
             img_render = self.unwarp(img_render, depth)
 
             # Compute PSNR and SSIM
-            render_psnr = round(batch_psnr(img, img_render), 3)
-            render_ssim = round(batch_ssim(img, img_render), 3)
+            render_psnr = round(batch_psnr(img, img_render).item(), 3)
+            render_ssim = round(batch_ssim(img, img_render).item(), 3)
             print(f"Rendered image (unwarped): PSNR={render_psnr:.3f}, SSIM={render_ssim:.3f}")
 
             if save_name is not None:

--- a/deeplens/geolens.py
+++ b/deeplens/geolens.py
@@ -575,7 +575,7 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
         if record:
             ray_o = ray.o.clone().detach()
             # Set to NaN to be skipped in 2d layout visualization
-            ray_o[ray.valid == 0] = float("nan")
+            ray_o[ray.is_valid == 0] = float("nan")
             ray_o_record.append(ray_o)
             return ray, ray_o_record
         else:
@@ -604,7 +604,7 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
 
             if record:
                 ray_out_o = ray.o.clone().detach()
-                ray_out_o[ray.valid == 0] = float("nan")
+                ray_out_o[ray.is_valid == 0] = float("nan")
                 ray_o_record.append(ray_out_o)
 
         return ray, ray_o_record
@@ -632,7 +632,7 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
 
             if record:
                 ray_out_o = ray.o.clone().detach()
-                ray_out_o[ray.valid == 0] = float("nan")
+                ray_out_o[ray.is_valid == 0] = float("nan")
                 ray_o_record.append(ray_out_o)
 
         return ray, ray_o_record
@@ -760,8 +760,8 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
         ray = ray.prop_to(depth)
         p = ray.o[..., :2]
         pixel_size = scale * self.pixel_size
-        ray.valid = (
-            ray.valid
+        ray.is_valid = (
+            ray.is_valid
             * (torch.abs(p[..., 0] / pixel_size) < (W / 2 + 1))
             * (torch.abs(p[..., 1] / pixel_size) < (H / 2 + 1))
         )
@@ -789,11 +789,11 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
 
         # Computation image
         if not vignetting:
-            image = torch.sum(irr_img * ray.valid, -1) / (
-                torch.sum(ray.valid, -1) + EPSILON
+            image = torch.sum(irr_img * ray.is_valid, -1) / (
+                torch.sum(ray.is_valid, -1) + EPSILON
             )
         else:
-            image = torch.sum(irr_img * ray.valid, -1) / torch.numel(ray.valid)
+            image = torch.sum(irr_img * ray.is_valid, -1) / torch.numel(ray.is_valid)
 
         return image
 
@@ -916,7 +916,7 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
             # Shrink the pupil and calculate green light centroid ray as the chief ray
             ray = self.sample_from_points(points, scale_pupil=0.5, num_rays=SPP_CALC)
             ray = self.trace2sensor(ray)
-            if not (ray.valid == 1).any():
+            if not (ray.is_valid == 1).any():
                 raise RuntimeError("When tracing chief ray for PSF center calculation, no ray arrives at the sensor.")
             psf_center = ray.centroid()
             psf_center = -psf_center[..., :2]  # shape [..., 2]
@@ -1199,9 +1199,9 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
                 ray_xy_center_green = ray.centroid()[..., :2].unsqueeze(-2)
 
             # Calculate RMS spot size and radius for different FoVs
-            ray_xy_norm = (ray.o[..., :2] - ray_xy_center_green) * ray.valid.unsqueeze(-1)
-            spot_rms = ((ray_xy_norm**2).sum(-1).sqrt() * ray.valid).sum(-1) / (
-                ray.valid.sum(-1) + EPSILON
+            ray_xy_norm = (ray.o[..., :2] - ray_xy_center_green) * ray.is_valid.unsqueeze(-1)
+            spot_rms = ((ray_xy_norm**2).sum(-1).sqrt() * ray.is_valid).sum(-1) / (
+                ray.is_valid.sum(-1) + EPSILON
             )
             spot_radius = (ray_xy_norm**2).sum(-1).sqrt().max(dim=-1).values
 
@@ -1268,7 +1268,7 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
         ray = self.trace2sensor(ray)
 
         # Compute the effective focal length
-        paraxial_imgh = (ray.o[:, 1] * ray.valid).sum() / ray.valid.sum()
+        paraxial_imgh = (ray.o[:, 1] * ray.is_valid).sum() / ray.is_valid.sum()
         eff_foclen = paraxial_imgh.item() / float(np.tan(paraxial_fov))
         self.efl = eff_foclen
         self.foclen = eff_foclen
@@ -1324,7 +1324,7 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
         t = (ray.d[..., 0] * ray.o[..., 0] + ray.d[..., 1] * ray.o[..., 1]) / (
             ray.d[..., 0] ** 2 + ray.d[..., 1] ** 2
         )
-        focus_z = (ray.o[..., 2] - ray.d[..., 2] * t)[ray.valid > 0].cpu().numpy()
+        focus_z = (ray.o[..., 2] - ray.d[..., 2] * t)[ray.is_valid > 0].cpu().numpy()
         focus_z = focus_z[~np.isnan(focus_z) & (focus_z < 0)]
 
         if len(focus_z) > 0:
@@ -1362,7 +1362,7 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
             ray.d[:, 0] ** 2 + ray.d[:, 1] ** 2
         )
         focus_z = ray.o[:, 2] - ray.d[:, 2] * t
-        focus_z = focus_z[ray.valid > 0]
+        focus_z = focus_z[ray.is_valid > 0]
         focus_z = focus_z[~torch.isnan(focus_z) & (focus_z > 0)]
         d_sensor = torch.mean(focus_z)
         return d_sensor
@@ -1405,7 +1405,7 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
 
         # Compute output ray angle
         tan_rfov = ray.d[..., 0] / ray.d[..., 2]
-        rfov = torch.atan(torch.sum(tan_rfov * ray.valid) / torch.sum(ray.valid))
+        rfov = torch.atan(torch.sum(tan_rfov * ray.is_valid) / torch.sum(ray.is_valid))
 
         # If calculation failed, use pinhole camera model to compute fov
         if torch.isnan(rfov):
@@ -1525,10 +1525,10 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
 
         # Compute intersection points, solving the equation: o1+d1*t1 = o2+d2*t2
         ray_o = torch.stack(
-            [ray.o[ray.valid != 0][:, 0], ray.o[ray.valid != 0][:, 2]], dim=-1
+            [ray.o[ray.is_valid != 0][:, 0], ray.o[ray.is_valid != 0][:, 2]], dim=-1
         )
         ray_d = torch.stack(
-            [ray.d[ray.valid != 0][:, 0], ray.d[ray.valid != 0][:, 2]], dim=-1
+            [ray.d[ray.is_valid != 0][:, 0], ray.d[ray.is_valid != 0][:, 2]], dim=-1
         )
         intersection_points = self.compute_intersection_points_2d(ray_o, ray_d)
 
@@ -1606,10 +1606,10 @@ class GeoLens(Lens, GeoLensEval, GeoLensOptim, GeoLensVis, GeoLensIO, GeoLensTol
 
         # Compute intersection points, solving the equation: o1+d1*t1 = o2+d2*t2
         ray_o = torch.stack(
-            [ray.o[ray.valid > 0][:, 0], ray.o[ray.valid > 0][:, 2]], dim=-1
+            [ray.o[ray.is_valid > 0][:, 0], ray.o[ray.is_valid > 0][:, 2]], dim=-1
         )
         ray_d = torch.stack(
-            [ray.d[ray.valid > 0][:, 0], ray.d[ray.valid > 0][:, 2]], dim=-1
+            [ray.d[ray.is_valid > 0][:, 0], ray.d[ray.is_valid > 0][:, 2]], dim=-1
         )
         intersection_points = self.compute_intersection_points_2d(ray_o, ray_d)
 

--- a/deeplens/geolens_pkg/eval.py
+++ b/deeplens/geolens_pkg/eval.py
@@ -109,7 +109,7 @@ class GeoLensEval:
             # Trace rays to sensor plane, shape [num_fov, num_rays, 3]
             ray = self.trace2sensor(ray)
             ray_o = ray.o.clone().cpu().numpy()
-            ray_valid = ray.valid.clone().cpu().numpy()
+            ray_valid = ray.is_valid.clone().cpu().numpy()
 
             color = RGB_COLORS[wvln_idx % len(RGB_COLORS)]
 
@@ -173,7 +173,7 @@ class GeoLensEval:
 
             # Convert to numpy, shape [num_grid, num_grid, num_rays, 3]
             ray_o = -ray.o.clone().cpu().numpy()
-            ray_valid = ray.valid.clone().cpu().numpy()
+            ray_valid = ray.is_valid.clone().cpu().numpy()
 
             color = RGB_COLORS[wvln_idx % len(RGB_COLORS)]
 
@@ -224,7 +224,7 @@ class GeoLensEval:
 
             ray = self.trace2sensor(ray)
             ray_xy = ray.o[..., :2]
-            ray_valid = ray.valid
+            ray_valid = ray.is_valid
 
             # Calculate green centroid as reference, shape [num_grid, num_grid, 2]
             if i == 0:
@@ -269,7 +269,7 @@ class GeoLensEval:
         )
         ray = self.trace2sensor(ray)
         ray_xy = ray.o[..., :2]  # Shape [num_grid, num_grid, spp, 2]
-        ray_valid = ray.valid  # Shape [num_grid, num_grid, spp]
+        ray_valid = ray.is_valid  # Shape [num_grid, num_grid, spp]
 
         # Calculate centroid for each field point for this wavelength
         ray_xy_center = (ray_xy * ray_valid.unsqueeze(-1)).sum(-2) / ray_valid.sum(
@@ -674,7 +674,7 @@ class GeoLensEval:
             da = ray.d[..., axis_idx : axis_idx + 1]
             pos_axis = (oa + da * t).squeeze(-1)  # [N, Z]
 
-            w = ray.valid.unsqueeze(-1).float()  # [N, 1] -> [N, Z] by broadcast
+            w = ray.is_valid.unsqueeze(-1).float()  # [N, 1] -> [N, Z] by broadcast
             pos_axis = pos_axis * w
             w_sum = w.sum(0)  # [Z]
             centroid = pos_axis.sum(0) / (w_sum + EPSILON)  # [Z]
@@ -752,7 +752,7 @@ class GeoLensEval:
         ray = self.trace2sensor(ray)
 
         # Calculate vignetting map
-        vignetting = ray.valid.sum(-1) / (ray.valid.shape[-1])
+        vignetting = ray.is_valid.sum(-1) / (ray.is_valid.shape[-1])
         return vignetting
 
     def draw_vignetting(self, filename=None, depth=DEPTH, resolution=512, show=False):

--- a/deeplens/geolens_pkg/optim.py
+++ b/deeplens/geolens_pkg/optim.py
@@ -579,7 +579,7 @@ class GeoLensOptim:
 
                 # Ray error to center and valid mask
                 ray_xy = ray.o[..., :2]
-                ray_valid = ray.valid
+                ray_valid = ray.is_valid
                 ray_err = ray_xy - center_ref
 
                 # Weight mask, shape of [num_grid, num_grid]

--- a/deeplens/hybridlens.py
+++ b/deeplens/hybridlens.py
@@ -359,11 +359,11 @@ class HybridLens(Lens):
             # Draw wave propagation
             # Calculate ray center for wave propagation visualization
             ray_center_doe = (
-                ((ray.o * ray.valid.unsqueeze(-1)).sum(dim=0) / ray.valid.sum()).cpu().numpy()
+                ((ray.o * ray.is_valid.unsqueeze(-1)).sum(dim=0) / ray.is_valid.sum()).cpu().numpy()
             )  # shape [3]
             ray.prop_to(geolens.d_sensor)  # shape [num_rays, 3]
             ray_center_sensor = (
-                ((ray.o * ray.valid.unsqueeze(-1)).sum(dim=0) / ray.valid.sum()).cpu().numpy()
+                ((ray.o * ray.is_valid.unsqueeze(-1)).sum(dim=0) / ray.is_valid.sum()).cpu().numpy()
             )  # shape [3]
 
             arc_radi = ray_center_sensor[2] - ray_center_doe[2]

--- a/deeplens/optics/geometric_surface/plane.py
+++ b/deeplens/optics/geometric_surface/plane.py
@@ -52,17 +52,17 @@ class Plane(Surface):
             valid = (
                 (torch.abs(new_o[..., 0]) < self.w / 2)
                 & (torch.abs(new_o[..., 1]) < self.h / 2)
-                & (ray.valid > 0)
+                & (ray.is_valid > 0)
             )
         else:
             valid = (torch.sqrt(new_o[..., 0] ** 2 + new_o[..., 1] ** 2) < self.r) & (
-                ray.valid > 0
+                ray.is_valid > 0
             )
 
         # Update rays
         new_o = ray.o + ray.d * t.unsqueeze(-1)
         ray.o = torch.where(valid.unsqueeze(-1), new_o, ray.o)
-        ray.valid = ray.valid * valid
+        ray.is_valid = ray.is_valid * valid
 
         if ray.coherent:
             ray.opl = torch.where(

--- a/deeplens/optics/geometric_surface/spheric.py
+++ b/deeplens/optics/geometric_surface/spheric.py
@@ -146,7 +146,7 @@ class Spheric(Surface):
             t = (0.0 - ray.o[..., 2]) / ray.d[..., 2]
             new_o = ray.o + t.unsqueeze(-1) * ray.d
             valid = (torch.sqrt(new_o[..., 0] ** 2 + new_o[..., 1] ** 2) < self.r) & (
-                ray.valid > 0
+                ray.is_valid > 0
             )
         else:
             R = 1.0 / c
@@ -183,11 +183,11 @@ class Spheric(Surface):
             r_squared = new_o[..., 0] ** 2 + new_o[..., 1] ** 2
             within_aperture = r_squared <= (self.r**2 + EPSILON)
 
-            valid = valid_intersect & within_aperture & (ray.valid > 0)
+            valid = valid_intersect & within_aperture & (ray.is_valid > 0)
 
         # Update ray position
         ray.o = torch.where(valid.unsqueeze(-1), new_o, ray.o)
-        ray.valid = ray.valid * valid
+        ray.is_valid = ray.is_valid * valid
 
         if ray.coherent:
             if t.abs().max() > 100 and torch.get_default_dtype() == torch.float32:

--- a/deeplens/optics/geometric_surface/thinlens.py
+++ b/deeplens/optics/geometric_surface/thinlens.py
@@ -59,7 +59,7 @@ class ThinLens(Plane):
         (1) Lens maker's equation
         (2) Spherical lens function
         """
-        forward = (ray.d * ray.valid.unsqueeze(-1))[..., 2].sum() > 0
+        forward = (ray.d * ray.is_valid.unsqueeze(-1))[..., 2].sum() > 0
 
         # Calculate convergence point
         if forward:
@@ -87,7 +87,7 @@ class ThinLens(Plane):
 
         # Optical path length change
         if ray.coherent:
-            valid = ray.valid > 0
+            valid = ray.is_valid > 0
             if forward:
                 new_opl = (
                     ray.opl

--- a/deeplens/optics/monte_carlo.py
+++ b/deeplens/optics/monte_carlo.py
@@ -35,7 +35,7 @@ def forward_integral(ray, ps, ks, pointc=None):
         single_point = False
 
     points = ray.o[..., :2]  # shape [N, spp, 2]
-    valid = ray.valid  # shape [N, spp]
+    valid = ray.is_valid  # shape [N, spp]
 
     # Points shift relative to center
     if pointc is None:
@@ -258,7 +258,7 @@ def backward_integral(
             out_img = img[..., idx_i, idx_j]
 
         # Monte-Carlo integration
-        output = torch.sum(out_img * ray.valid * energy_correction, -3) / (
-            torch.sum(ray.valid, -3) + EPSILON
+        output = torch.sum(out_img * ray.is_valid * energy_correction, -3) / (
+            torch.sum(ray.is_valid, -3) + EPSILON
         )
         return output

--- a/deeplens/optics/monte_carlo.py
+++ b/deeplens/optics/monte_carlo.py
@@ -62,7 +62,7 @@ def forward_integral(ray, ps, ks, pointc=None):
         amp = torch.sqrt(ray.d[..., 2].abs())  # [N, spp], sqrt(cos(dz))
         opl = ray.opl.squeeze(-1)  # [N, spp]
         opl_min = opl.min(dim=-1, keepdim=True).values  # [N, 1]
-        wvln_mm = ray.wvln.squeeze(-1) * 1e-3  # [N, spp]
+        wvln_mm = ray.wvln * 1e-3  # [1], broadcasts with [N, spp]
         phase = torch.fmod((opl - opl_min) / wvln_mm, 1) * (2 * torch.pi)  # [N, spp]
         value = amp * torch.exp(1j * phase)  # [N, spp], complex amplitude
     else:

--- a/deeplens/optics/phase_surface/phase.py
+++ b/deeplens/optics/phase_surface/phase.py
@@ -130,17 +130,17 @@ class Phase(DeepObj):
             valid = (
                 (torch.abs(new_o[..., 0]) < self.w / 2)
                 & (torch.abs(new_o[..., 1]) < self.h / 2)
-                & (ray.valid > 0)
+                & (ray.is_valid > 0)
             )
         else:
             valid = (torch.sqrt(new_o[..., 0] ** 2 + new_o[..., 1] ** 2) < self.r) & (
-                ray.valid > 0
+                ray.is_valid > 0
             )
 
         # Update rays
         new_o = ray.o + ray.d * t.unsqueeze(-1)
         ray.o = torch.where(valid.unsqueeze(-1), new_o, ray.o)
-        ray.valid = ray.valid * valid
+        ray.is_valid = ray.is_valid * valid
 
         if ray.coherent:
             ray.opl = torch.where(
@@ -158,8 +158,8 @@ class Phase(DeepObj):
             [1] https://support.zemax.com/hc/en-us/articles/1500005489061-How-diffractive-surfaces-are-modeled-in-OpticStudio
             [2] Light propagation with phase discontinuities: generalized laws of reflection and refraction. Science 2011.
         """
-        forward = (ray.d * ray.valid.unsqueeze(-1))[..., 2].sum() > 0
-        valid = ray.valid > 0
+        forward = (ray.d * ray.is_valid.unsqueeze(-1))[..., 2].sum() > 0
+        valid = ray.is_valid > 0
 
         # Diffraction 1: DOE phase modulation
         if ray.coherent:
@@ -204,7 +204,7 @@ class Phase(DeepObj):
         k = 1 - eta**2 * (1 - dot_product**2)
 
         # Total internal reflection
-        valid = (k >= 0).squeeze(-1) & (ray.valid > 0)
+        valid = (k >= 0).squeeze(-1) & (ray.is_valid > 0)
         k = k * valid.unsqueeze(-1)
 
         # Update ray direction
@@ -212,7 +212,7 @@ class Phase(DeepObj):
         ray.d = torch.where(valid.unsqueeze(-1), new_d, ray.d)
 
         # Update ray valid mask
-        ray.valid = ray.valid * valid
+        ray.is_valid = ray.is_valid * valid
 
         return ray
 

--- a/deeplens/optics/phase_surface/phase.py
+++ b/deeplens/optics/phase_surface/phase.py
@@ -171,7 +171,7 @@ class Phase(DeepObj):
         # Perpendicular incident rays are diffracted following (1) grating equation and (2) local grating approximation
         dphidx, dphidy = self.dphi_dxy(ray.o[..., 0], ray.o[..., 1])
 
-        wvln_mm = ray.wvln.squeeze(-1) * 1e-3
+        wvln_mm = ray.wvln * 1e-3
         order = self.diffraction_order
         if forward:
             new_d_x = ray.d[..., 0] + wvln_mm / (2 * torch.pi) * dphidx * order

--- a/deeplens/optics/ray.py
+++ b/deeplens/optics/ray.py
@@ -30,7 +30,7 @@ class Ray(DeepObj):
         self.d = d if torch.is_tensor(d) else torch.tensor(d)
         self.shape = self.o.shape[:-1]
         assert wvln > 0.1 and wvln < 1, "Ray wavelength unit should be [um]"
-        self.wvln = torch.full((*self.shape, 1), wvln)
+        self.wvln = torch.tensor(wvln)
 
         # Auxiliary ray parameters
         self.valid = torch.ones(self.shape)
@@ -127,7 +127,7 @@ class Ray(DeepObj):
         """
         self.o = self.o.squeeze(dim)
         self.d = self.d.squeeze(dim)
-        self.wvln = self.wvln.squeeze(dim)
+        # wvln is a single element tensor, no squeeze needed
         self.valid = self.valid.squeeze(dim)
         self.en = self.en.squeeze(dim)
         self.opl = self.opl.squeeze(dim)
@@ -143,7 +143,7 @@ class Ray(DeepObj):
         """
         self.o = self.o.unsqueeze(dim)
         self.d = self.d.unsqueeze(dim)
-        self.wvln = self.wvln.unsqueeze(dim)
+        # wvln is a single element tensor, no unsqueeze needed
         self.valid = self.valid.unsqueeze(dim)
         self.en = self.en.unsqueeze(dim)
         self.opl = self.opl.unsqueeze(dim)

--- a/deeplens/optics/ray.py
+++ b/deeplens/optics/ray.py
@@ -33,7 +33,7 @@ class Ray(DeepObj):
         self.wvln = torch.tensor(wvln)
 
         # Auxiliary ray parameters
-        self.valid = torch.ones(self.shape)
+        self.is_valid = torch.ones(self.shape)
         self.en = torch.ones((*self.shape, 1))
         self.obliq = torch.ones((*self.shape, 1))
 
@@ -53,7 +53,7 @@ class Ray(DeepObj):
         """
         t = (z - self.o[..., 2]) / self.d[..., 2]
         new_o = self.o + self.d * t.unsqueeze(-1)
-        valid_mask = (self.valid > 0).unsqueeze(-1)
+        valid_mask = (self.is_valid > 0).unsqueeze(-1)
         self.o = torch.where(valid_mask, new_o, self.o)
 
         if self.coherent:
@@ -71,7 +71,7 @@ class Ray(DeepObj):
         Returns:
             torch.Tensor: Centroid of the ray, shape (..., 3)
         """
-        return (self.o * self.valid.unsqueeze(-1)).sum(-2) / self.valid.sum(-1).add(
+        return (self.o * self.is_valid.unsqueeze(-1)).sum(-2) / self.is_valid.sum(-1).add(
             EPSILON
         ).unsqueeze(-1)
 
@@ -93,7 +93,7 @@ class Ray(DeepObj):
 
         # Calculate RMS error for each region
         rms_error = ((self.o[..., :2] - center_ref[..., :2]) ** 2).sum(-1)
-        rms_error = (rms_error * self.valid).sum(-1) / (self.valid.sum(-1) + EPSILON)
+        rms_error = (rms_error * self.is_valid).sum(-1) / (self.is_valid.sum(-1) + EPSILON)
         rms_error = rms_error.sqrt()
 
         # Average RMS error
@@ -127,11 +127,10 @@ class Ray(DeepObj):
         self.o = self.o.squeeze(dim)
         self.d = self.d.squeeze(dim)
         # wvln is a single element tensor, no squeeze needed
-        self.valid = self.valid.squeeze(dim)
+        self.is_valid = self.is_valid.squeeze(dim)
         self.en = self.en.squeeze(dim)
         self.opl = self.opl.squeeze(dim)
         self.obliq = self.obliq.squeeze(dim)
-        self.is_forward = self.is_forward.squeeze(dim)
         return self
 
     def unsqueeze(self, dim=None):
@@ -143,9 +142,8 @@ class Ray(DeepObj):
         self.o = self.o.unsqueeze(dim)
         self.d = self.d.unsqueeze(dim)
         # wvln is a single element tensor, no unsqueeze needed
-        self.valid = self.valid.unsqueeze(dim)
+        self.is_valid = self.is_valid.unsqueeze(dim)
         self.en = self.en.unsqueeze(dim)
         self.opl = self.opl.unsqueeze(dim)
         self.obliq = self.obliq.unsqueeze(dim)
-        self.is_forward = self.is_forward.unsqueeze(dim)
         return self

--- a/deeplens/optics/ray.py
+++ b/deeplens/optics/ray.py
@@ -36,7 +36,6 @@ class Ray(DeepObj):
         self.valid = torch.ones(self.shape)
         self.en = torch.ones((*self.shape, 1))
         self.obliq = torch.ones((*self.shape, 1))
-        self.is_forward = self.d[..., 2].unsqueeze(-1) > 0
 
         # Coherent ray tracing
         self.coherent = coherent  # bool

--- a/test/test_geolens.py
+++ b/test/test_geolens.py
@@ -330,6 +330,34 @@ class TestGeoLensRendering:
         
         assert img_render.min() >= 0
 
+    def test_geolens_analysis_rendering(self, sample_cellphone_lens, sample_image_small, test_output_dir):
+        """Should run analysis_rendering and return rendered image."""
+        import os
+        lens = sample_cellphone_lens
+        # Convert [B, C, H, W] to [H, W, C] format expected by analysis_rendering
+        img = sample_image_small.squeeze(0).permute(1, 2, 0)
+        save_path = os.path.join(test_output_dir, "analysis_render_test")
+        
+        # Run analysis_rendering
+        img_render = lens.analysis_rendering(
+            img_org=img, 
+            depth=DEPTH, 
+            spp=64,
+            save_name=save_path,
+            method="ray_tracing",
+            show=False
+        )
+        
+        # Check output shape [B, C, H, W]
+        assert img_render is not None
+        assert len(img_render.shape) == 4
+        assert img_render.shape[1] == 3  # RGB channels
+        # Check values are in valid range
+        assert img_render.min() >= 0
+        assert img_render.max() <= 1
+        # Check that output file was saved
+        assert os.path.exists(f"{save_path}.png")
+
 
 class TestGeoLensProperties:
     """Test lens property calculations."""

--- a/test/test_geolens.py
+++ b/test/test_geolens.py
@@ -133,7 +133,7 @@ class TestGeoLensTracing:
         ray_out, _ = lens.trace(ray)
         
         assert ray_out is not None
-        assert ray_out.valid.sum() > 0
+        assert ray_out.is_valid.sum() > 0
 
     def test_geolens_trace_with_record(self, sample_singlet_lens):
         """Should record ray path during tracing."""
@@ -150,10 +150,10 @@ class TestGeoLensTracing:
         lens = sample_singlet_lens
         
         ray = lens.sample_parallel(fov_x=[0.0], fov_y=[0.0], num_rays=512)
-        valid_before = ray.valid.sum().item()
+        valid_before = ray.is_valid.sum().item()
         
         ray_out, _ = lens.trace(ray)
-        valid_after = ray_out.valid.sum().item()
+        valid_after = ray_out.is_valid.sum().item()
         
         assert valid_after <= valid_before
         assert valid_after > 0  # Some rays should survive

--- a/test/test_monte_carlo.py
+++ b/test/test_monte_carlo.py
@@ -51,7 +51,7 @@ class TestForwardIntegral:
         field = forward_integral(ray, ps=ps, ks=ks)
         
         # Sum should be approximately n_rays (number of valid rays)
-        valid_count = ray.valid.sum().item()
+        valid_count = ray.is_valid.sum().item()
         assert field.sum().item() == pytest.approx(valid_count, rel=0.2)
 
     def test_forward_integral_with_center(self, device_auto):

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -89,16 +89,6 @@ class TestRayInit:
         
         assert torch.all(ray.opl == 0.0)
 
-    def test_ray_is_forward(self, device_auto):
-        """Ray should track forward/backward direction."""
-        o = torch.zeros(2, 3, device=device_auto)
-        d = torch.tensor([[0.0, 0.0, 1.0], [0.0, 0.0, -1.0]], device=device_auto)
-        
-        ray = Ray(o, d, wvln=0.55, device=device_auto)
-        
-        assert ray.is_forward[0, 0] == True
-        assert ray.is_forward[1, 0] == False
-
 
 class TestRayPropTo:
     """Test ray propagation."""

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -21,7 +21,7 @@ class TestRayInit:
         
         assert ray.o.shape == (1, 3)
         assert ray.d.shape == (1, 3)
-        assert ray.wvln.shape == (1, 1)
+        assert ray.wvln.shape == ()  # 0D scalar tensor
 
     def test_ray_init_batch(self, device_auto):
         """Ray should support batch initialization."""
@@ -63,7 +63,7 @@ class TestRayInit:
         
         # Valid wavelength (0.55 um = 550 nm)
         ray = Ray(o, d, wvln=0.55, device=device_auto)
-        assert ray.wvln[0, 0] == 0.55
+        assert torch.isclose(ray.wvln, torch.tensor(0.55, device=device_auto)).item()
         
         # Wavelength out of range should raise
         with pytest.raises(AssertionError):

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -77,7 +77,7 @@ class TestRayInit:
         
         ray = Ray(o, d, wvln=0.55, device=device_auto)
         
-        assert torch.all(ray.valid == 1.0)
+        assert torch.all(ray.is_valid == 1.0)
 
     def test_ray_init_opl_zero(self, device_auto):
         """Ray should initialize with zero optical path length."""
@@ -133,7 +133,7 @@ class TestRayPropTo:
         d[:, 2] = 1.0
         ray = Ray(o, d, wvln=0.55, device=device_auto)
         
-        ray.valid[1] = 0.0  # Invalidate second ray
+        ray.is_valid[1] = 0.0  # Invalidate second ray
         original_o = ray.o.clone()
         
         ray.prop_to(z=10.0)
@@ -186,7 +186,7 @@ class TestRayCentroid:
         d[:, 2] = 1.0
         ray = Ray(o, d, wvln=0.55, device=device_auto)
         
-        ray.valid[1] = 0.0  # Invalidate second ray
+        ray.is_valid[1] = 0.0  # Invalidate second ray
         
         centroid = ray.centroid()
         

--- a/test/test_surfaces.py
+++ b/test/test_surfaces.py
@@ -235,8 +235,8 @@ class TestApertureSurface:
         ray_in = aper.ray_reaction(ray_in)
         ray_out = aper.ray_reaction(ray_out)
         
-        assert ray_in.valid[0].item() == 1.0
-        assert ray_out.valid[0].item() == 0.0
+        assert ray_in.is_valid[0].item() == 1.0
+        assert ray_out.is_valid[0].item() == 0.0
 
     def test_aperture_surf_dict(self, device_auto):
         """Aperture should export to dictionary."""


### PR DESCRIPTION
1. ray.wvln to scalar tensor for memory saving
2. ray.valid rename to ray.is_valid
3. bugfixing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the ray validity mask to `ray.is_valid`, makes `ray.wvln` a scalar tensor, updates all ray-surface/trace/render/PSF code and tests accordingly, and enables 3D visualization in `GeoLens`.
> 
> - **Core Optics (Ray/Surfaces/Monte Carlo)**:
>   - Rename `ray.valid` → `ray.is_valid` across all computations (intersection, refraction/reflection, propagation, integration, rendering backprop).
>   - Change `Ray.wvln` to a scalar tensor; remove shape-dependent squeeze/unsqueeze; adjust coherent phase calculations to use scalar `wvln`.
>   - Update `ThinLens`, `Plane`, `Spheric`, `Phase`, and base `Surface` logic to use `is_valid`.
>   - Monte Carlo `forward_integral`/`backward_integral` now use `is_valid`; phase uses scalar `wvln`.
> - **GeoLens**:
>   - Enable and inherit `GeoLensVis3D` (`from ...view_3d import GeoLensVis3D`).
>   - Replace `valid` usage with `is_valid` in tracing, rendering, RMS/spot/vignetting/FoV/field-curvature, pupil calculations, and PSF centers.
>   - Metrics: call `.item()` on `batch_psnr`/`batch_ssim` in analysis outputs.
> - **Rendering & Analysis**:
>   - Rendering pipeline (`render_compute_image`, `analysis_rendering`) updated to `is_valid` and corrected averaging.
> - **HybridLens**:
>   - Update centroid computations to `is_valid`.
> - **Imports**:
>   - Change `PSFLoss` import to `deeplens.optics.loss`.
> - **Tests**:
>   - Update tests to `ray.is_valid` and scalar `ray.wvln`; add analysis rendering test; adjust Monte Carlo expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3000575fec731234cf08ddfdf3bce7b4c127ccb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->