### PR TITLE
[Feat] Huygens PSF

### DIFF
--- a/5_pupil_field.py
+++ b/5_pupil_field.py
@@ -1,4 +1,4 @@
-"""Calculates the pupil field (wavefront) of the lens for a point object in space by coherent ray tracing. 
+"""Calculates the pupil field (wavefront) of the lens for a point object in space by coherent ray tracing.
 
 Note: Wavefront error is the relative error between the actual wavefront and the ideal spherical wavefront. In commercial software (e.g., Zemax), wavefront error is calculated by interpolation, which requires a low-frequency wavefront aberration. While in DeepLens, we doesnot rely on interpolation and the calculation is also accurate for high-frequency wavefront.
 
@@ -8,27 +8,85 @@ Technical Paper:
 
 import torch
 from torchvision.utils import save_image
+import matplotlib.pyplot as plt
 
 from deeplens import GeoLens
 
 
 def main():
     # Better to use a high sensor resolution (4000x4000 is roughly acceptable, but higher is better)
-    lens = GeoLens(filename="./datasets/lenses/cellphone/cellphone80deg.json", dtype=torch.float64)
+    lens = GeoLens(
+        filename="./datasets/lenses/cellphone/cellphone68deg.json",
+        dtype=torch.float64,
+    )
     lens.set_sensor_res(sensor_res=(8000, 8000))
 
-    # Calculate the pupil field
+    # ==========================================================
+    # Calculate the exit-pupil field by coherent ray tracing
+    # ==========================================================
     wavefront, _ = lens.pupil_field(
-        point=torch.tensor([0.0, 0.0, -10000.0]), spp=100000000
+        point=torch.tensor([0.0, 0.0, -10000.0]), spp=20_000_000
     )
     save_image(wavefront.angle(), "./wavefront_phase.png")
     save_image(torch.abs(wavefront), "./wavefront_amp.png")
 
-    # Compare coherent and incoherent PSFs
-    psf_coherent = lens.psf_coherent(torch.tensor([0.0, 0.0, -10000.0]), ks=64)
+    # ==========================================================
+    # Compare three different PSFs:
+    #   1. geometric PSF
+    #   2. Huygens PSF
+    #   3. Exit-pupil propagated PSF (mathematically equivalent to Huygens PSF)
+    # ==========================================================
+    psf_coherent = lens.psf_coherent(torch.tensor([0.0, 0.4, -10000.0]), ks=64)
     save_image(psf_coherent, "./psf_coherent.png", normalize=True)
-    psf_incoherent = lens.psf(torch.tensor([0.0, 0.0, -10000.0]), ks=64)
+
+    psf_incoherent = lens.psf(torch.tensor([0.0, 0.4, -10000.0]), ks=64)
     save_image(psf_incoherent, "./psf_incoherent.png", normalize=True)
+
+    psf_huygens = lens.psf_huygens(torch.tensor([0.0, 0.4, -10000.0]), ks=64)
+    save_image(psf_huygens, "./psf_huygens.png", normalize=True)
+
+    # ==========================================================
+    # Plot PSF values along the center line
+    # ==========================================================
+    center_y = psf_coherent.shape[-2] // 2
+
+    # Extract center line profiles (sum over channels if RGB)
+    if psf_coherent.dim() == 3:  # [C, H, W]
+        coherent_center = psf_coherent[:, center_y, :].mean(dim=0).cpu().numpy()
+        incoherent_center = psf_incoherent[:, center_y, :].mean(dim=0).cpu().numpy()
+        huygens_center = psf_huygens[:, center_y, :].mean(dim=0).cpu().numpy()
+    else:  # [H, W]
+        coherent_center = psf_coherent[center_y, :].cpu().numpy()
+        incoherent_center = psf_incoherent[center_y, :].cpu().numpy()
+        huygens_center = psf_huygens[center_y, :].cpu().numpy()
+
+    # Create the plot
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+    # Linear scale plot
+    axes[0].plot(coherent_center, label="Pupil PSF", alpha=0.8)
+    axes[0].plot(incoherent_center, label="Geometric PSF", alpha=0.8)
+    axes[0].plot(huygens_center, label="Huygens PSF", alpha=0.8)
+    axes[0].set_xlabel("Pixel Position")
+    axes[0].set_ylabel("Intensity")
+    axes[0].set_title("PSF Center Line Profile (Linear Scale)")
+    axes[0].legend()
+    axes[0].grid(True, alpha=0.3)
+
+    # Log scale plot to better visualize peaks and diffraction orders
+    axes[1].semilogy(coherent_center + 1e-10, label="Pupil PSF", alpha=0.8)
+    axes[1].semilogy(incoherent_center + 1e-10, label="Geometric PSF", alpha=0.8)
+    axes[1].semilogy(huygens_center + 1e-10, label="Huygens PSF", alpha=0.8)
+    axes[1].set_xlabel("Pixel Position")
+    axes[1].set_ylabel("Intensity (log scale)")
+    axes[1].set_title("PSF Center Line Profile (Log Scale)")
+    axes[1].legend()
+    axes[1].grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    plt.savefig("./psf_center_line_profile.png", dpi=150)
+    plt.close()
+    print("Saved PSF center line profile to ./psf_center_line_profile.png")
 
 
 if __name__ == "__main__":

--- a/deeplens/lens.py
+++ b/deeplens/lens.py
@@ -92,10 +92,10 @@ class Lens(DeepObj):
         # Change sensor size (r_sensor is fixed)
         diam_res = float(np.sqrt(self.sensor_res[0] ** 2 + self.sensor_res[1] ** 2))
         self.sensor_size = (
-            round(2 * self.r_sensor * self.sensor_res[0] / diam_res, 4),
-            round(2 * self.r_sensor * self.sensor_res[1] / diam_res, 4),
+            2 * self.r_sensor * self.sensor_res[0] / diam_res,
+            2 * self.r_sensor * self.sensor_res[1] / diam_res,
         )
-        self.pixel_size = round(self.sensor_size[0] / self.sensor_res[0], 4)
+        self.pixel_size = self.sensor_size[0] / self.sensor_res[0]
         self.calc_fov()
 
     @torch.no_grad()

--- a/deeplens/optics/geometric_surface/aperture.py
+++ b/deeplens/optics/geometric_surface/aperture.py
@@ -31,7 +31,14 @@ class Aperture(Plane):
 
     @classmethod
     def init_from_dict(cls, surf_dict):
-        return cls(surf_dict["r"], surf_dict["d"])
+        return cls(
+            r=surf_dict["r"],
+            d=surf_dict["d"],
+            is_square=surf_dict["is_square"] if "is_square" in surf_dict else False,
+            pos_xy=surf_dict["pos_xy"] if "pos_xy" in surf_dict else [0.0, 0.0],
+            vec_local=surf_dict["vec_local"] if "vec_local" in surf_dict else [0.0, 0.0, 1.0],
+            device=surf_dict["device"] if "device" in surf_dict else "cpu",
+        )
 
     def ray_reaction(self, ray, n1=1.0, n2=1.0, refraction=False):
         """Compute output ray after intersection and refraction."""

--- a/deeplens/optics/geometric_surface/plane.py
+++ b/deeplens/optics/geometric_surface/plane.py
@@ -52,8 +52,8 @@ class Plane(Surface):
         # Aperture mask
         if self.is_square:
             valid = (
-                (torch.abs(new_o[..., 0]) < (self.w / 2))
-                & (torch.abs(new_o[..., 1]) < (self.h / 2))
+                (torch.abs(new_o[..., 0]) < self.w / 2)
+                & (torch.abs(new_o[..., 1]) < self.h / 2)
                 & (ray.is_valid > 0)
             )
         else:

--- a/deeplens/optics/geometric_surface/plane.py
+++ b/deeplens/optics/geometric_surface/plane.py
@@ -48,10 +48,12 @@ class Plane(Surface):
         # Solve intersection
         t = (0.0 - ray.o[..., 2]) / ray.d[..., 2]
         new_o = ray.o + t.unsqueeze(-1) * ray.d
+        
+        # Aperture mask
         if self.is_square:
             valid = (
-                (torch.abs(new_o[..., 0]) < self.w / 2)
-                & (torch.abs(new_o[..., 1]) < self.h / 2)
+                (torch.abs(new_o[..., 0]) < (self.w / 2))
+                & (torch.abs(new_o[..., 1]) < (self.h / 2))
                 & (ray.is_valid > 0)
             )
         else:

--- a/test/test_geolens.py
+++ b/test/test_geolens.py
@@ -222,12 +222,12 @@ class TestGeoLensPSF:
         original_dtype = torch.get_default_dtype()
         torch.set_default_dtype(torch.float64)
         try:
-            points = torch.tensor([[0.0, 0.0, DEPTH]], device=lens.device, dtype=torch.float64)
+            point = torch.tensor([0.0, 0.0, DEPTH], device=lens.device, dtype=torch.float64)
             # Use smaller spp for faster testing
-            psf = lens.psf(points, wvln=DEFAULT_WAVE, ks=31, mode="huygens", spp=10000)
+            psf = lens.psf_huygens(point, wvln=DEFAULT_WAVE, ks=31, spp=10000)
             
-            # PSF should have correct shape [N, ks, ks]
-            assert psf.shape == (1, 31, 31)
+            # PSF should have correct shape [ks, ks] for single point
+            assert psf.shape == (31, 31)
             # Huygens PSF should be real-valued (intensity)
             assert not psf.is_complex()
             # All values should be non-negative (intensity)
@@ -243,36 +243,12 @@ class TestGeoLensPSF:
         original_dtype = torch.get_default_dtype()
         torch.set_default_dtype(torch.float64)
         try:
-            points = torch.tensor([[0.0, 0.0, DEPTH]], device=lens.device, dtype=torch.float64)
-            psf = lens.psf(points, wvln=DEFAULT_WAVE, ks=51, mode="huygens", spp=10000)
+            point = torch.tensor([0.0, 0.0, DEPTH], device=lens.device, dtype=torch.float64)
+            psf = lens.psf_huygens(point, wvln=DEFAULT_WAVE, ks=51, spp=10000)
             
             # PSF should be normalized
-            assert psf.shape == (1, 51, 51)
+            assert psf.shape == (51, 51)
             assert psf.sum().item() == pytest.approx(1.0, abs=0.1)
-        finally:
-            torch.set_default_dtype(original_dtype)
-
-    def test_geolens_psf_huygens_batch(self, sample_cellphone_lens):
-        """Should compute Huygens PSF for multiple points."""
-        lens = sample_cellphone_lens
-        
-        # Huygens mode requires float64 for coherent ray tracing
-        original_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(torch.float64)
-        try:
-            # Multiple points
-            points = torch.tensor([
-                [0.0, 0.0, DEPTH],
-                [0.3, 0.0, DEPTH],
-                [0.0, 0.3, DEPTH]
-            ], device=lens.device, dtype=torch.float64)
-            psf = lens.psf(points, wvln=DEFAULT_WAVE, ks=31, mode="huygens", spp=10000)
-            
-            # Should have shape [N, ks, ks] for N points
-            assert psf.shape == (3, 31, 31)
-            # Each PSF should be normalized
-            for i in range(3):
-                assert psf[i].sum().item() == pytest.approx(1.0, abs=0.1)
         finally:
             torch.set_default_dtype(original_dtype)
 
@@ -284,14 +260,15 @@ class TestGeoLensPSF:
         original_dtype = torch.get_default_dtype()
         torch.set_default_dtype(torch.float64)
         try:
-            points = torch.tensor([[0.0, 0.0, DEPTH]], device=lens.device, dtype=torch.float64)
-            psf_geo = lens.psf(points, wvln=DEFAULT_WAVE, ks=31, mode="geometric", spp=10000)
-            psf_huygens = lens.psf(points, wvln=DEFAULT_WAVE, ks=31, mode="huygens", spp=10000)
+            point = torch.tensor([0.0, 0.0, DEPTH], device=lens.device, dtype=torch.float64)
+            psf_geo = lens.psf(point, wvln=DEFAULT_WAVE, ks=31, spp=10000)
+            psf_huygens = lens.psf_huygens(point, wvln=DEFAULT_WAVE, ks=31, spp=10000)
             
             # Both should have same shape
             assert psf_geo.shape == psf_huygens.shape
             # But different values (coherent vs incoherent)
-            assert not torch.allclose(psf_geo, psf_huygens, atol=1e-3)
+            # Convert to same dtype for comparison
+            assert not torch.allclose(psf_geo.to(torch.float64), psf_huygens.to(torch.float64), atol=1e-3)
         finally:
             torch.set_default_dtype(original_dtype)
 


### PR DESCRIPTION
1. Fix Huygens PSF to use the standard definition (same as TOG 2021).
2. Result alignment with exit-pupil propagation method (SIGGRAPH Asia 2025). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements coherent Huygens PSF and streamlines PSF APIs while improving pupil and aperture handling.
> 
> - Adds `GeoLens.psf_huygens` (coherent exit‑pupil tracing + Huygens–Fresnel integration), normalizes/flip outputs; `psf_coherent` now delegates to `psf_pupil_prop`; `psf` is geometric-only with `recenter` support; introduces `trace2exit_pupil`
> - Updates `pupil_field` to use `trace2exit_pupil`, supports `recenter`, and returns `psf_center`; standardizes intensity normalization across PSF paths
> - Aperture/geometry improvements: `Aperture.init_from_dict` accepts `is_square/pos_xy/vec_local/device`; `Plane.intersect` enforces square/round aperture masks; entrance‑pupil radius accounts for square apertures; `Lens.set_sensor_res` avoids rounding for precise `sensor_size/pixel_size`
> - Example `5_pupil_field.py` now computes and compares `psf` (geometric), `psf_huygens`, and `psf_coherent`/`psf_pupil_prop`, and plots center‑line profiles
> - Tests updated: new Huygens PSF coverage, adjusted shapes/API calls, and consistency checks with geometric PSF
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac0358e3b5c7e15218ebe18f5795c4062369fc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->