### PR TITLE
[Fix, Feat] psf center

### DIFF
--- a/2_autolens_rms.py
+++ b/2_autolens_rms.py
@@ -143,7 +143,7 @@ def curriculum_design(
                     )
                     rays_backup.append(ray)
 
-                center_ref = -self.psf_center(points=ray.o[:, :, 0, :], method="pinhole")
+                center_ref = -self.psf_center(points_obj=ray.o[:, :, 0, :], method="pinhole")
                 center_ref = center_ref.unsqueeze(-2).repeat(1, 1, spp, 1)
 
         # =======================================

--- a/deeplens/camera.py
+++ b/deeplens/camera.py
@@ -168,9 +168,9 @@ class Camera(Renderer):
             img_lq_ls = []
             for b in range(img_linrgb.shape[0]):
                 img = img_linrgb[b, ...].unsqueeze(0)
-                psf_center = kwargs["field_center"][b, ...]
+                patch_center = kwargs["field_center"][b, ...]
                 img_lq = self.lens.render(
-                    img, method="psf_patch", psf_center=psf_center
+                    img, method="psf_patch", patch_center=patch_center
                 )
                 img_lq_ls.append(img_lq)
             img_lq = torch.cat(img_lq_ls, dim=0)
@@ -189,10 +189,10 @@ class Camera(Renderer):
             img_lq_ls = []
             for b in range(img_linrgb.shape[0]):
                 img = img_linrgb[b, ...].unsqueeze(0)
-                psf_center = kwargs["field_center"][b, ...].unsqueeze(0)
+                patch_center = kwargs["field_center"][b, ...].unsqueeze(0)
                 depth = kwargs["depth"][b, ...].unsqueeze(0)
                 img_lq = self.lens.render_rgbd(
-                    img, depth, method="psf_patch", psf_center=psf_center
+                    img, depth, method="psf_patch", patch_center=patch_center
                 )
                 img_lq_ls.append(img_lq)
             img_lq = torch.cat(img_lq_ls, dim=0)

--- a/deeplens/geolens.py
+++ b/deeplens/geolens.py
@@ -734,7 +734,7 @@ class GeoLens(
             **kwargs: Additional arguments for different methods:
                 - psf_grid (tuple): Grid size for PSF map method. Defaults to (10, 10).
                 - psf_ks (int): Kernel size for PSF methods. Defaults to PSF_KS.
-                - psf_center (tuple): Center position for PSF patch method.
+                - patch_center (tuple): Center position for PSF patch method.
                 - spp (int): Samples per pixel for ray tracing. Defaults to SPP_RENDER.
 
         Returns:
@@ -757,10 +757,10 @@ class GeoLens(
 
         elif method == "psf_patch":
             # PSF patch rendering - uses a single PSF to render a patch of the image
-            psf_center = kwargs.get("psf_center", (0.0, 0.0))
+            patch_center = kwargs.get("patch_center", (0.0, 0.0))
             psf_ks = kwargs.get("psf_ks", PSF_KS)
             img_render = self.render_psf_patch(
-                img_obj, depth=depth, psf_center=psf_center, psf_ks=psf_ks
+                img_obj, depth=depth, patch_center=patch_center, psf_ks=psf_ks
             )
 
         elif method == "ray_tracing":

--- a/deeplens/geolens_pkg/optim.py
+++ b/deeplens/geolens_pkg/optim.py
@@ -434,7 +434,7 @@ class GeoLensOptim:
             # Calculate reference center, shape of (..., 2)
             if i == 0:
                 with torch.no_grad():
-                    ray_center_green = -self.psf_center(points=ray.o[:, :, 0, :], method="pinhole")
+                    ray_center_green = -self.psf_center(points_obj=ray.o[:, :, 0, :], method="pinhole")
 
             ray = self.trace2sensor(ray)
 
@@ -564,10 +564,10 @@ class GeoLensOptim:
 
                     # Calculate ray centers
                     if centroid:
-                        center_ref = -self.psf_center(points=ray.o[:, :, 0, :], method="chief_ray")
+                        center_ref = -self.psf_center(points_obj=ray.o[:, :, 0, :], method="chief_ray")
                         center_ref = center_ref.unsqueeze(-2).repeat(1, 1, spp, 1)
                     else:
-                        center_ref = -self.psf_center(points=ray.o[:, :, 0, :], method="pinhole")
+                        center_ref = -self.psf_center(points_obj=ray.o[:, :, 0, :], method="pinhole")
                         center_ref = center_ref.unsqueeze(-2).repeat(1, 1, spp, 1)
 
             # ===> Optimize lens by minimizing RMS

--- a/deeplens/paraxiallens.py
+++ b/deeplens/paraxiallens.py
@@ -300,15 +300,15 @@ class ParaxialLens(Lens):
         depth_min = depth.min()
         depth_max = depth.max()
         num_depth = 10
-        psf_center = (0.0, 0.0)
+        patch_center = (0.0, 0.0)
         psf_ks = PSF_KS
 
         # Calculate dual-pixel PSF at reference depths
         depths_ref = torch.linspace(depth_min, depth_max, num_depth).to(self.device)
         points = torch.stack(
             [
-                torch.full_like(depths_ref, psf_center[0]),
-                torch.full_like(depths_ref, psf_center[1]),
+                torch.full_like(depths_ref, patch_center[0]),
+                torch.full_like(depths_ref, patch_center[1]),
                 depths_ref,
             ],
             dim=-1,

--- a/docs/api/geolens.rst
+++ b/docs/api/geolens.rst
@@ -358,7 +358,7 @@ Main Rendering
    :type method: str
    :param kwargs: Additional method-specific arguments:
       - For "psf_map": psf_grid=(10,10), psf_ks=64
-      - For "psf_patch": psf_center=(0.0,0.0), psf_ks=64
+      - For "psf_patch": patch_center=(0.0,0.0), psf_ks=64
       - For "ray_tracing": spp=64
    :return: Rendered image tensor [B, C, H, W]
    :rtype: torch.Tensor

--- a/docs/api/geolens.rst
+++ b/docs/api/geolens.rst
@@ -713,6 +713,15 @@ Distortion
    :return: Distortion map [num_grid, num_grid, 2]
    :rtype: torch.Tensor
 
+.. py:method:: GeoLens.distortion_center(points)
+
+   Calculate the distortion center for given normalized points.
+
+   :param points: Normalized point source positions [..., 3]. x, y in [-1, 1], z (depth) in [-Inf, 0]
+   :type points: torch.Tensor
+   :return: Normalized distortion center positions [..., 2]. x, y in [-1, 1]
+   :rtype: torch.Tensor
+
 .. py:method:: GeoLens.draw_distortion(filename=None, num_grid=16, depth=-10000.0)
 
    Visualize distortion map.

--- a/docs/api/geolens.rst
+++ b/docs/api/geolens.rst
@@ -544,12 +544,14 @@ PSF Calculation
    :return: PSF map [grid_h, grid_w, 1, ks, ks]
    :rtype: torch.Tensor
 
-.. py:method:: GeoLens.psf_center(points, method="chief_ray")
+.. py:method:: GeoLens.psf_center(points_obj, method="chief_ray")
 
    Calculate PSF center position on sensor.
 
-   :param points: Point source positions [..., 3]
-   :type points: torch.Tensor
+   :param points_obj: Un-normalized point source positions in object plane [..., 3]
+   :type points_obj: torch.Tensor
+   :param method: Calculation method - "chief_ray" or "pinhole". Defaults to "chief_ray".
+   :type method: str
    :return: PSF centers [..., 2]
    :rtype: torch.Tensor
 

--- a/docs/api/lens.rst
+++ b/docs/api/lens.rst
@@ -36,7 +36,7 @@ Base Lens Class
       :type depth: float
       :param method: Rendering method - 'psf_map' or 'psf_patch'
       :type method: str
-      :param kwargs: Additional method-specific arguments (psf_grid, psf_ks, psf_center)
+      :param kwargs: Additional method-specific arguments (psf_grid, psf_ks, patch_center)
       :return: Rendered image tensor [B, C, H, W]
       :rtype: torch.Tensor
 


### PR DESCRIPTION
This pull request standardizes the naming of parameters related to PSF (Point Spread Function) patch rendering, changing all instances of `psf_center` to `patch_center` across the codebase and documentation. It also introduces a new `distortion_center` method for the `GeoLens` class, which calculates the distortion center for normalized points. Comprehensive tests for distortion calculations have been added, and docstrings have been updated for clarity and consistency.

**Parameter Renaming and Standardization**

* Renamed all occurrences of the `psf_center` parameter to `patch_center` in PSF patch rendering methods and related function signatures in `deeplens/lens.py`, `deeplens/geolens.py`, `deeplens/camera.py`, and `deeplens/paraxiallens.py` to improve clarity and consistency. [[1]](diffhunk://#diff-fb17886a130970d60e9fd381555240e4b3d3e5e060c3927e9f8a95ceadca6e08L737-R737) [[2]](diffhunk://#diff-fb17886a130970d60e9fd381555240e4b3d3e5e060c3927e9f8a95ceadca6e08L760-R763) [[3]](diffhunk://#diff-0b479953db1a9302a1c914fd619a3fa002a9326ce6a0e6dc0b515b804cf59179L435-R435) [[4]](diffhunk://#diff-0b479953db1a9302a1c914fd619a3fa002a9326ce6a0e6dc0b515b804cf59179L451-R477) [[5]](diffhunk://#diff-0b479953db1a9302a1c914fd619a3fa002a9326ce6a0e6dc0b515b804cf59179L530-R527) [[6]](diffhunk://#diff-0b479953db1a9302a1c914fd619a3fa002a9326ce6a0e6dc0b515b804cf59179L540-R538) [[7]](diffhunk://#diff-02ee43d174f6a9c97793fdd4ff8dd2ae9adbb25cd2dde7024a9abfd87ffdf9c7L171-R173) [[8]](diffhunk://#diff-02ee43d174f6a9c97793fdd4ff8dd2ae9adbb25cd2dde7024a9abfd87ffdf9c7L192-R195) [[9]](diffhunk://#diff-adbc481552efc0fce76b582c627ec255e104902795b8148249d91d960a8485c4L303-R311)
* Updated all usage sites and docstrings to use `patch_center` instead of `psf_center`, including in API documentation (`docs/api/geolens.rst`, `docs/api/lens.rst`). [[1]](diffhunk://#diff-6fb98b22a4d72cc830914dda8dbd996a92c66a051475b25595ab1c916a7a4290L361-R361) [[2]](diffhunk://#diff-1e93e5f47a608d1a5fe2735040c402264eb8fd43e8dc175541b477af18ccc05aL39-R39)

**API and Internal Method Improvements**

* Changed the signature of `psf_center` to accept `points_obj` instead of `points`, and updated all calls and docstrings accordingly for clarity and explicitness. [[1]](diffhunk://#diff-fb17886a130970d60e9fd381555240e4b3d3e5e060c3927e9f8a95ceadca6e08L1463-R1475) [[2]](diffhunk://#diff-fb17886a130970d60e9fd381555240e4b3d3e5e060c3927e9f8a95ceadca6e08L1485-R1491) [[3]](diffhunk://#diff-7a78704a5798d608fa66439f7e54858aef4b071eae81a5bbfc23b563018e9ffcL146-R146) [[4]](diffhunk://#diff-abb5176c52b4597476175df067e5ca7142a991ab9c91cb9fbf880c3c9c3015d6L437-R437) [[5]](diffhunk://#diff-abb5176c52b4597476175df067e5ca7142a991ab9c91cb9fbf880c3c9c3015d6L567-R570) [[6]](diffhunk://#diff-6fb98b22a4d72cc830914dda8dbd996a92c66a051475b25595ab1c916a7a4290L547-R554)
* Improved the docstring of the `psf` method in `deeplens/lens.py` for clarity regarding input shapes and removed redundant references.

**New Feature: Distortion Center Calculation**

* Added a new `distortion_center` method to the `GeoLens` class in `deeplens/geolens_pkg/eval.py` to compute the normalized distortion center for given points, with corresponding API documentation. [[1]](diffhunk://#diff-7e6cd0d082ea352f47b256ab5aeb986b1ab46e19b82a49256859722e0b989335R446-R476) [[2]](diffhunk://#diff-6fb98b22a4d72cc830914dda8dbd996a92c66a051475b25595ab1c916a7a4290R716-R724)

**Testing Enhancements**

* Added comprehensive unit tests for distortion map and distortion center calculations, including tests for single and multiple points, as well as for output normalization, in `test/test_geolens.py`.