### PR TITLE
Fix RMS spot size calculation order

### DIFF
--- a/2_autolens_rms.py
+++ b/2_autolens_rms.py
@@ -172,8 +172,9 @@ def curriculum_design(
                     weight_mask = weight_mask * (~dropout_mask)
 
             # Loss on rms error, shape of [num_grid, num_grid]
-            l_rms = (((ray_err**2).sum(-1) + EPSILON).sqrt() * ray_valid).sum(-1)
+            l_rms = ((ray_err**2).sum(-1) * ray_valid).sum(-1)
             l_rms /= ray_valid.sum(-1) + EPSILON
+            l_rms = (l_rms + EPSILON).sqrt()
 
             # Weighted loss
             l_rms_weighted = (l_rms * weight_mask).sum()

--- a/deeplens/geolens.py
+++ b/deeplens/geolens.py
@@ -1538,9 +1538,10 @@ class GeoLens(
             ray_xy_norm = (
                 ray.o[..., :2] - ray_xy_center_green
             ) * ray.is_valid.unsqueeze(-1)
-            spot_rms = ((ray_xy_norm**2).sum(-1).sqrt() * ray.is_valid).sum(-1) / (
-                ray.is_valid.sum(-1) + EPSILON
-            )
+            spot_rms = (
+                ((ray_xy_norm**2).sum(-1) * ray.is_valid).sum(-1)
+                / (ray.is_valid.sum(-1) + EPSILON)
+            ).sqrt()
             spot_radius = (ray_xy_norm**2).sum(-1).sqrt().max(dim=-1).values
 
             # Append to list

--- a/deeplens/geolens_pkg/optim.py
+++ b/deeplens/geolens_pkg/optim.py
@@ -590,9 +590,9 @@ class GeoLensOptim:
                         weight_mask /= weight_mask.mean()
 
                 # Loss on RMS error
-                l_rms = (((ray_err**2).sum(-1) + EPSILON).sqrt() * ray_valid).sum(-1) # l2 loss
-                # l_rms = (ray_err.abs().sum(-1) * ray_valid).sum(-1) # l1 loss
+                l_rms = ((ray_err**2).sum(-1) * ray_valid).sum(-1)
                 l_rms /= ray_valid.sum(-1) + EPSILON
+                l_rms = (l_rms + EPSILON).sqrt()
 
                 # Weighted loss
                 l_rms_weighted = (l_rms * weight_mask).sum()


### PR DESCRIPTION
## Summary
- **Fix RMS formula**: compute `sqrt(mean(x^2))` instead of `mean(sqrt(x^2))` in `geolens.py`, `optim.py`, and `2_autolens_rms.py`
- **Numerical stability**: add `EPSILON` inside `sqrt` in training loss paths to prevent NaN gradients from `sqrt(0)` when field points have zero valid rays

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)